### PR TITLE
fix: correctly parse toolbar options in ->setOptions()

### DIFF
--- a/views/field.blade.php
+++ b/views/field.blade.php
@@ -1,7 +1,7 @@
 @component($typeForm, get_defined_vars())
     <div data-controller="ckeditor"
          data-ckeditor-id-value="{{ $id }}"
-         data-ckeditor-options-value="{{ json_encode($options, flags: JSON_FORCE_OBJECT) }}"
+         data-ckeditor-options-value="{{ json_encode($options) }}"
          data-ckeditor-editor-url-value="{{ config('ckeditor.editorUrl') }}"
     >
         <div data-ckeditor-target="editor"></div>


### PR DESCRIPTION
Previously, calling ->setOptions([
	'toolbar' => [
		['Bold', 'Italic', 'Underline'],
	],
]) did not work because the array was parsed as an object in the view, resulting in:
data-ckeditor-options-value='{"toolbar":{"0":{"0":"Bold","1":"Italic","2":"Underline"}}}'

Now, the options are correctly parsed as an array, producing:
data-ckeditor-options-value='{"toolbar":[["Bold","Italic","Underline"]]}'